### PR TITLE
Adds mkdirp which is a missing dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "del": "^2.2.0",
     "mocha": "^2.5.3",
-    "webpack": "^1.13.1"
+    "webpack": "^1.13.1",
+    "mkdirp": "^0.5.1"
   }
 }


### PR DESCRIPTION
When I tried to use the library for the first time I got this error:

```
Error: Cannot find module 'mkdirp'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/david/src/pentagine.js/node_modules/unminified-webpack-plugin/index.js:6:14)
    at Module._compile (module.js:434:26)
    at Module._extensions..js (module.js:452:10)
    at require.extensions.(anonymous function) (/Users/david/src/pentagine.js/node_modules/babel-core/node_modules/babel-register/lib/node.js:166:7)
    at Object.require.extensions.(anonymous function) [as .js] (/usr/local/lib/node_modules/babel/lib/babel/api/register/node.js:113:7)
    at Module.load (module.js:355:32)
```

As so, I think you should add `mkdirp` as a dev dependency.