### PR TITLE
Add disclaimer that BannerPlugin is incompatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ module.exports = {
 
 By doing as above, you will get two files `library.min.js` and `library.js`. No need execute `webpack` twice, it just works!^^
 
+**Note:** Does not work with `BannerPlugin`, see [this comment](https://github.com/leftstick/unminified-webpack-plugin/issues/1#issuecomment-226413904) for an explanation.
+
 ## Configuration ##
 
 `postfix`: you can specify the `nomin` part as you wish. `nomin` is the default postfix once you haven't specify `min` in `output.filename`. And it can be customized by specifying this option, following is example:


### PR DESCRIPTION
It took some research for me to figure out that `webpack.BannerPlugin` is incompatible with this plugin, so I figured I would save future users some time by adding it to the README.

I cannot use this plugin because I need the banner on my output file. If I had seen this disclaimer before installing, I would have known to not use the plugin in the first place.

Despite the fact that I cannot use it, I appreciate the simplicity and effectiveness of this plugin and thank you for building it, @leftstick!