### PR TITLE
Replace the last occurrence of 'min' in instead of the first

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers');
 
 
 var getFileName = function(name, opts) {
-    var minIndex = name.indexOf('min');
+    var minIndex = name.lastIndexOf('min');
     if (minIndex > -1) {
         return name.substring(0, minIndex - 1) + name.substring(minIndex + 3);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,32 @@ describe('testing', function() {
         });
     });
 
+    it('generating while UglifyJsPlugin specified and min in the bundle name', function(done) {
+        var compiler = webpack({
+            entry: {
+                index: resolve(curDir, 'simple', 'index.js')
+            },
+            output: {
+                path: resolve(curDir, 'build'),
+                filename: 'minimal.min.js'
+            },
+            plugins: [
+                new webpack.BannerPlugin('The fucking shit'),
+                new webpack.optimize.UglifyJsPlugin({
+                    compress: {
+                        warnings: false
+                    }
+                }),
+                new UnminifiedWebpackPlugin()
+            ]
+        });
+
+        compiler.run(function(err, stats) {
+            assert(fileExist(resolve(curDir, 'build', 'minimal.js')));
+            done();
+        });
+    });
+
     it('generating while nonmin options specified', function(done) {
         var compiler = webpack({
             entry: {


### PR DESCRIPTION
Previously, if you used any of the words in this list
http://www.morewords.com/contains/min/ to name your bundle (for
example, `minimal.min.js`) then this plugin would strip the first min
resulting in a file named `imal.min.js` which makes no sense.

This change switches the `min` replacement to look for the last
occurrence of min instead of the first, since that is the more common
naming convention for minified files.