### PR TITLE
Extended UglifyJs check to test for new 'mode' config

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ UnminifiedWebpackPlugin.prototype.apply = function(compiler) {
         return plugin.constructor.name === 'UglifyJsPlugin';
     });
 
-    if (!containUgly.length) {
+    if (!containUgly.length && !(compiler.options.mode && compiler.options.mode === 'production')) {
         return console.log('Ignore generating unminified version, since no UglifyJsPlugin provided');
     }
 


### PR DESCRIPTION
Webpack 4 automatically runs UglifyJs when in production mode (see "Big changes" in https://github.com/webpack/webpack/releases/tag/v4.0.0-beta.0, e.g.). However, it isn't exposed in `options.plugins` anymore.

I'm not sure whether this is a reasonable approach, but it seems to work fine in my local setup with Webpack 4.