### PR TITLE
Webpack 4 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ UnminifiedWebpackPlugin.prototype.apply = function(compiler) {
         return console.log('Ignore generating unminified version, since no UglifyJsPlugin provided');
     }
 
-    compiler.plugin('compilation', function(compilation) {
-        compilation.plugin('additional-assets', function(cb) {
+    compiler.hooks.compilation.tap('UnminifiedWebpackPlugin', function(compilation) {
+        compilation.hooks.additionalAssets.tap('UnminifiedWebpackPlugin', function(cb) {
             const files = [];
             compilation.chunks.forEach(function(chunk) {
                 chunk.files.forEach(function(file) {

--- a/index.js
+++ b/index.js
@@ -27,12 +27,12 @@ UnminifiedWebpackPlugin.prototype.apply = function(compiler) {
         return plugin.constructor.name === 'UglifyJsPlugin';
     });
 
-    if (!containUgly.length) {
+    if (!containUgly.length && compiler.options.mode === 'development') {
         return console.log('Ignore generating unminified version, since no UglifyJsPlugin provided');
     }
 
     compiler.hooks.compilation.tap('UnminifiedWebpackPlugin', function(compilation) {
-        compilation.hooks.additionalAssets.tap('UnminifiedWebpackPlugin', function(cb) {
+        compilation.hooks.additionalAssets.tap('UnminifiedWebpackPlugin', function() {
             const files = [];
             compilation.chunks.forEach(function(chunk) {
                 chunk.files.forEach(function(file) {
@@ -66,7 +66,6 @@ UnminifiedWebpackPlugin.prototype.apply = function(compiler) {
                     }
                 };
             });
-            cb();
         });
 
     });

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "devDependencies": {
     "del": "^3.0.0",
     "mocha": "^4.0.1",
-    "webpack": "^3.6.0"
+    "webpack": "^4.0.0-beta.0"
+  },
+  "peerDependencies": {
+    "webpack": "^4.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,7 @@ describe('testing', function() {
 
     it('ignoring while no UglifyJsPlugin specified', function(done) {
         var compiler = webpack({
+            mode: 'development',
             entry: {
                 index: resolve(curDir, 'simple', 'index.js')
             },
@@ -66,11 +67,6 @@ describe('testing', function() {
                 },
                 plugins: [
                     new webpack.BannerPlugin('The fucking shit'),
-                    new webpack.optimize.UglifyJsPlugin({
-                        compress: {
-                            warnings: false
-                        }
-                    }),
                     new UnminifiedWebpackPlugin()
                 ]
             });
@@ -91,11 +87,6 @@ describe('testing', function() {
                     filename: 'admin.js'
                 },
                 plugins: [
-                    new webpack.optimize.UglifyJsPlugin({
-                        compress: {
-                            warnings: false
-                        }
-                    }),
                     new UnminifiedWebpackPlugin()
                 ]
             });
@@ -116,11 +107,6 @@ describe('testing', function() {
                     filename: 'ad-min.js'
                 },
                 plugins: [
-                    new webpack.optimize.UglifyJsPlugin({
-                        compress: {
-                            warnings: false
-                        }
-                    }),
                     new UnminifiedWebpackPlugin()
                 ]
             });
@@ -141,11 +127,6 @@ describe('testing', function() {
                     filename: 'ad-min-1.0.0.js'
                 },
                 plugins: [
-                    new webpack.optimize.UglifyJsPlugin({
-                        compress: {
-                            warnings: false
-                        }
-                    }),
                     new UnminifiedWebpackPlugin()
                 ]
             });
@@ -166,11 +147,6 @@ describe('testing', function() {
                     filename: 'Admin/js/Admin.js'
                 },
                 plugins: [
-                    new webpack.optimize.UglifyJsPlugin({
-                        compress: {
-                            warnings: false
-                        }
-                    }),
                     new UnminifiedWebpackPlugin()
                 ]
             });
@@ -195,11 +171,6 @@ describe('testing', function() {
             },
             plugins: [
                 new webpack.BannerPlugin('The fucking shit'),
-                new webpack.optimize.UglifyJsPlugin({
-                    compress: {
-                        warnings: false
-                    }
-                }),
                 new UnminifiedWebpackPlugin()
             ]
         });
@@ -221,11 +192,6 @@ describe('testing', function() {
             },
             plugins: [
                 new webpack.BannerPlugin('The fucking shit'),
-                new webpack.optimize.UglifyJsPlugin({
-                    compress: {
-                        warnings: false
-                    }
-                }),
                 new UnminifiedWebpackPlugin({postfix: 'nnnmin'})
             ]
         });
@@ -246,11 +212,6 @@ describe('testing', function() {
                 filename: 'bundle.min.js'
             },
             plugins: [
-                new webpack.optimize.UglifyJsPlugin({
-                    compress: {
-                        warnings: false
-                    }
-                }),
                 new UnminifiedWebpackPlugin({include: 'nothing'})
             ]
         });
@@ -271,11 +232,6 @@ describe('testing', function() {
                 filename: 'bundle.min.js'
             },
             plugins: [
-                new webpack.optimize.UglifyJsPlugin({
-                    compress: {
-                        warnings: false
-                    }
-                }),
                 new UnminifiedWebpackPlugin({include: /ad.*/})
             ]
         });
@@ -297,11 +253,6 @@ describe('testing', function() {
             },
             plugins: [
                 new webpack.BannerPlugin('This is a real test'),
-                new webpack.optimize.UglifyJsPlugin({
-                    compress: {
-                        warnings: false
-                    }
-                }),
                 new UnminifiedWebpackPlugin()
             ]
         });


### PR DESCRIPTION
Webpack 4 will introduce some changes affecting this plugin (see https://github.com/webpack/webpack/releases/tag/v4.0.0-beta.0):
- UglifyJS will be enabled by default when in production mode. This requires an updated check since it will be missing in `options.plugins`
- There is a new plugin system, requiring plugins to use `.hooks` over `.plugin`