### PR TITLE
Fixed invalid json in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module.exports = {
     },
     plugins: [
         new UnminifiedWebpackPlugin({
-            postfix: 'unmin'//specify "nomin" postfix,
+            postfix: 'unmin',//specify "nomin" postfix
             include: /polyfill.*/,
             exclude: /test.*/
         })


### PR DESCRIPTION
The options for UnminifiedWebpackPlugin had its , commented out, so moved it back before the comment.